### PR TITLE
Add a query linter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,21 @@ The tree can be toggled using the command `:TSPlaygroundToggle`.
 - `o`: Toggles the query editor when the playground is focused
 - `<cr>`: Go to current node in code buffer
 
+## Query Linter
+
+The playground can lint the queries for you. For that you need to activate the `query_linter` module:
+
+```lua
+require "nvim-treesitter.configs".setup {
+  query_linter = {
+    module_path = "nvim-treesitter-playground.query_linter",
+    use_virtual_text = true,
+    lint_events = {"BufWrite", "CursorHold"},
+  },
+}
+```
+
+![image](https://user-images.githubusercontent.com/7189118/101246661-06089a00-3715-11eb-9c57-6d6439defbf8.png)
+
 # Roadmap
   - [ ] Add interactive query highlighting

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ The tree can be toggled using the command `:TSPlaygroundToggle`.
 
 ## Query Linter
 
-The playground can lint the queries for you. For that you need to activate the `query_linter` module:
+The playground can lint query files for you. For that, you need to activate the `query_linter` module:
 
 ```lua
 require "nvim-treesitter.configs".setup {
   query_linter = {
-    module_path = "nvim-treesitter-playground.query_linter",
+    enable = true,
     use_virtual_text = true,
     lint_events = {"BufWrite", "CursorHold"},
   },

--- a/lua/nvim-treesitter-playground.lua
+++ b/lua/nvim-treesitter-playground.lua
@@ -17,7 +17,7 @@ function M.init()
       use_virtual_text = true,
       lint_events = {"BufWrite", "CursorHold"},
       is_supported = function(lang)
-        return lang == 'query' and parsers.has_parser('query')
+        return lang == "query" and parsers.has_parser("query")
       end,
     },
   }

--- a/lua/nvim-treesitter-playground.lua
+++ b/lua/nvim-treesitter-playground.lua
@@ -14,6 +14,8 @@ function M.init()
     },
     query_linter = {
       module_path = "nvim-treesitter-playground.query_linter",
+      use_virtual_text = true,
+      lint_events = {"BufWrite", "CursorHold"},
       is_supported = function(lang)
         return lang == 'query' and parsers.has_parser('query')
       end,

--- a/lua/nvim-treesitter-playground.lua
+++ b/lua/nvim-treesitter-playground.lua
@@ -1,3 +1,4 @@
+local parsers = require 'nvim-treesitter.parsers'
 local M = {}
 
 vim.cmd [[
@@ -10,7 +11,13 @@ function M.init()
       module_path = "nvim-treesitter-playground.internal",
       updatetime = 25,
       persist_queries = false
-    }
+    },
+    query_linter = {
+      module_path = "nvim-treesitter-playground.query_linter",
+      is_supported = function(lang)
+        return lang == 'query' and parsers.has_parser('query')
+      end,
+    },
   }
 end
 

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -63,7 +63,7 @@ function M.lint(buf)
         local node_type = ts_utils.get_node_text(node)[1]
 
         if anonymous_node then
-          node_type = node_type.sub(2, -2)
+          node_type = node_type:sub(2, -2)
         end
 
         local found =

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -2,7 +2,7 @@ local api = vim.api
 local queries = require "nvim-treesitter.query"
 local ts_utils = require "nvim-treesitter.ts_utils"
 local utils = require "nvim-treesitter.utils"
-local configs = require'nvim-treesitter.configs'
+local configs = require "nvim-treesitter.configs"
 
 local hl_namespace = api.nvim_create_namespace("nvim-playground-lints")
 local ERROR_HL = "TSQueryLinterError"
@@ -14,15 +14,17 @@ M.lints = {}
 M.use_virtual_text = true
 M.lint_events = {"BufWrite", "CursorHold"}
 
-local function lint_node(node, buf, message_prefix)
-  ts_utils.highlight_node(node, buf, hl_namespace, ERROR_HL)
+local function lint_node(node, buf, error_type, complete_message)
+  if error_type ~= "Invalid Query" then
+    ts_utils.highlight_node(node, buf, hl_namespace, ERROR_HL)
+  end
   local node_text = table.concat(ts_utils.get_node_text(node, buf), " ")
-  local error_text = message_prefix .. ": " .. node_text
+  local error_text = complete_message or error_type .. ": " .. node_text
   local error_range = {node:range()}
   if M.use_virtual_text then
     api.nvim_buf_set_virtual_text(buf, hl_namespace, error_range[1], {{error_text, ERROR_HL}}, {})
   end
-  table.insert(M.lints[buf], {type = message_prefix, range = error_range, message = node_text})
+  table.insert(M.lints[buf], {type = error_type, range = error_range, message = error_text, node_text = node_text})
 end
 
 local function table_contains(predicate, table)
@@ -41,6 +43,7 @@ function M.lint(buf)
 
   local filename = api.nvim_buf_get_name(buf)
   local ok, query_lang = pcall(vim.fn.fnamemodify, filename, ":p:h:t")
+  query_lang = filename ~= "" and query_lang
   local query_lang = ok and query_lang
   local ok, parser_info = pcall(vim.treesitter.inspect_language, query_lang)
   local parser_info = ok and parser_info
@@ -54,42 +57,54 @@ function M.lint(buf)
       lint_node(error_node, buf, "Syntax Error")
     end
 
+    local toplevel_node = utils.get_at_path(m, "toplevel-query.node")
+    if toplevel_node and query_lang then
+      local query_text = table.concat(ts_utils.get_node_text(toplevel_node), "\n")
+      local ok, err = pcall(vim.treesitter.parse_query, query_lang, query_text)
+      if not ok then
+        lint_node(toplevel_node, buf, "Invalid Query", err)
+      end
+    end
+
     if parser_info and parser_info.symbols then
       local named_node = utils.get_at_path(m, "named_node.node")
       local anonymous_node = utils.get_at_path(m, "anonymous_node.node")
-
-      if named_node or anonymous_node then
-        local node = named_node or anonymous_node
+      local node = named_node or anonymous_node
+      if node then
         local node_type = ts_utils.get_node_text(node)[1]
 
         if anonymous_node then
-          node_type = node_type:gsub('"(.*)".*$', '%1')
+          node_type = node_type:gsub('"(.*)".*$', "%1")
         end
+
+        local is_named = named_node ~= nil
 
         local found =
           vim.tbl_contains(MAGIC_NODE_NAMES, node_type) or
           table_contains(
             function(t)
-              return node_type == t[1]
+              return node_type == t[1] and is_named == t[2]
             end,
             parser_info.symbols
           )
+
         if not found then
           lint_node(node, buf, "Invalid Node Type")
         end
       end
-    end
 
-    local field_node = utils.get_at_path(m, "field.node")
+      local field_node = utils.get_at_path(m, "field.node")
 
-    if field_node then
-      local field_name = ts_utils.get_node_text(field_node)[1]
-      local found = vim.tbl_contains(parser_info.fields, field_name)
-      if not found then
-        lint_node(field_node, buf, "Invalid Field")
+      if field_node then
+        local field_name = ts_utils.get_node_text(field_node)[1]
+        local found = vim.tbl_contains(parser_info.fields, field_name)
+        if not found then
+          lint_node(field_node, buf, "Invalid Field")
+        end
       end
     end
   end
+  return M.lints[buf]
 end
 
 function M.clear_virtual_text(buf)
@@ -108,7 +123,7 @@ function M.attach(buf, _)
   for _, e in pairs(M.lint_events) do
     vim.cmd(
       string.format(
-        [[autocmd %s <buffer=%d> lua require'nvim-treesitter-playground.query_linter'.lint(%d)]],
+        [[autocmd! %s <buffer=%d> lua require'nvim-treesitter-playground.query_linter'.lint(%d)]],
         e,
         buf,
         buf

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -74,6 +74,16 @@ function M.lint(buf)
         end
       end
     end
+
+    local field_node = utils.get_at_path(m, "field.node")
+
+    if field_node then
+      local field_name = ts_utils.get_node_text(field_node)[1]
+      local found = vim.tbl_contains(parser_info.fields, field_name)
+      if not found then
+        lint_node(field_node, buf, "Invalid Field")
+      end
+    end
   end
 end
 

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -1,0 +1,97 @@
+local api = vim.api
+local queries = require "nvim-treesitter.query"
+local ts_utils = require "nvim-treesitter.ts_utils"
+local utils = require "nvim-treesitter.utils"
+
+local hl_namespace = api.nvim_create_namespace("nvim-playground-lints")
+local ERROR_HL = "TSQueryLinterError"
+
+local M = {}
+
+M.lints = {}
+M.use_virtual_text = true
+
+local function lint_node(node, buf, message_prefix)
+    ts_utils.highlight_node(node, buf, hl_namespace, ERROR_HL)
+    local error_text = message_prefix..': '..table.concat(ts_utils.get_node_text(node, buf), ' ')
+    local error_range = {node:range()}
+    if M.use_virtual_text then
+      api.nvim_buf_set_virtual_text(buf, hl_namespace, error_range[1], {{error_text, ERROR_HL}}, {})
+    end
+    table.insert(M.lints[buf], { type = message_prefix, range = error_range, message = error_text })
+end
+
+local function table_contains(predicate, table)
+  for _, elt in pairs(table) do
+    if predicate(elt) then
+      return true
+    end
+  end
+  return false
+end
+
+function M.lint(buf)
+  buf = buf or api.nvim_get_current_buf()
+  M.clear_virtual_text(buf)
+  M.lints[buf] = {}
+
+  local filename = api.nvim_buf_get_name(buf)
+  local ok, query_lang = pcall(vim.fn.fnamemodify, filename, ":p:h:t")
+  local query_lang = ok and query_lang
+  local ok, parser_info = pcall(vim.treesitter.inspect_language, query_lang)
+  local parser_info = ok and parser_info
+
+  local matches = queries.get_matches(buf, "query-linter-queries")
+
+  for _, m in pairs(matches) do
+    local error_node = utils.get_at_path(m, "error.node")
+
+    if error_node then
+      lint_node(error_node, buf, "Syntax Error")
+    end
+
+    if parser_info and parser_info.symbols then
+
+      --for _, p in pairs(parser_info.symbols) do
+        --D(p[1])
+      --end
+
+      local named_node = utils.get_at_path(m, "named_node.node")
+      if named_node then
+        local node_type = ts_utils.get_node_text(named_node)[1]
+        local found = node_type == '_' or table_contains(function(t) return node_type == t[1]..'' end, parser_info.symbols)
+        if not found then
+          lint_node(named_node, buf, "Invalid Node Type")
+        end
+      end
+    end
+
+  end
+end
+
+function M.clear_virtual_text(buf)
+  api.nvim_buf_clear_namespace(buf, hl_namespace, 0, -1)
+end
+
+function M.attach(buf, _)
+  M.lints[buf] = {}
+
+  vim.cmd(string.format("augroup TreesitterPlaygroundLint_%d", buf))
+  vim.cmd "au!"
+  vim.cmd(
+    string.format(
+      [[autocmd CursorHold <buffer=%d> lua require'nvim-treesitter-playground.query_linter'.lint(%d)]],
+      buf,
+      buf
+    )
+  )
+  vim.cmd "augroup END"
+end
+
+function M.detach(buf)
+  M.lints[buf] = nil
+  M.clear_virtual_text(buf)
+  vim.cmd(string.format("autocmd! TreesitterPlaygroundLint_%d CursorHold", buf))
+end
+
+return M

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -2,6 +2,7 @@ local api = vim.api
 local queries = require "nvim-treesitter.query"
 local ts_utils = require "nvim-treesitter.ts_utils"
 local utils = require "nvim-treesitter.utils"
+local configs = require'nvim-treesitter.configs'
 
 local hl_namespace = api.nvim_create_namespace("nvim-playground-lints")
 local ERROR_HL = "TSQueryLinterError"
@@ -58,9 +59,13 @@ function M.lint(buf)
       local anonymous_node = utils.get_at_path(m, "anonymous_node.node")
 
       if named_node or anonymous_node then
-        local node_type =
-          named_node and ts_utils.get_node_text(named_node)[1] or ts_utils.get_node_text(anonymous_node)[1]:sub(2, -2)
         local node = named_node or anonymous_node
+        local node_type = ts_utils.get_node_text(node)[1]
+
+        if anonymous_node then
+          node_type = node_type.sub(2, -2)
+        end
+
         local found =
           vim.tbl_contains(MAGIC_NODE_NAMES, node_type) or
           table_contains(
@@ -93,6 +98,10 @@ end
 
 function M.attach(buf, _)
   M.lints[buf] = {}
+
+  local config = configs.get_module("query_linter")
+  M.use_virtual_text = config.use_virtual_text
+  M.lint_events = config.lint_events
 
   vim.cmd(string.format("augroup TreesitterPlaygroundLint_%d", buf))
   vim.cmd "au!"

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -63,7 +63,7 @@ function M.lint(buf)
         local node_type = ts_utils.get_node_text(node)[1]
 
         if anonymous_node then
-          node_type = node_type:sub(2, -2)
+          node_type = node_type:gsub('"(.*)".*$', '%1')
         end
 
         local found =

--- a/plugin/nvim-treesitter-playground.vim
+++ b/plugin/nvim-treesitter-playground.vim
@@ -3,5 +3,6 @@ require "nvim-treesitter-playground".init()
 EOF
 
 highlight default link TSPlaygroundFocus Visual
+highlight default link TSQueryLinterError Error
 
 command! TSPlaygroundToggle lua require "nvim-treesitter-playground.internal".toggle()

--- a/queries/query/query-linter-queries.scm
+++ b/queries/query/query-linter-queries.scm
@@ -1,0 +1,4 @@
+(program (named_node) @toplevel-query)
+(named_node
+   name: (identifier) @named_node)
+(ERROR) @error

--- a/queries/query/query-linter-queries.scm
+++ b/queries/query/query-linter-queries.scm
@@ -1,5 +1,7 @@
-(program (named_node) @toplevel-query)
+(program [(named_node) (list)] @toplevel-query)
 (named_node
    name: (identifier) @named_node)
 (ERROR) @error
 (anonymous_node) @anonymous_node
+(field_definition
+ name: (identifier) @field)

--- a/queries/query/query-linter-queries.scm
+++ b/queries/query/query-linter-queries.scm
@@ -2,3 +2,4 @@
 (named_node
    name: (identifier) @named_node)
 (ERROR) @error
+(anonymous_node) @anonymous_node


### PR DESCRIPTION
First draft for a query linter

I plan to actually parse top-level queries to see whether nvim accepts them. 

![image](https://user-images.githubusercontent.com/7189118/101246174-e15ef300-3711-11eb-853a-c2fef1cdbf3b.png)

TODO: 

- [ ] lint inherits (by parsing also the inherited files)
- [x] actually parse top-level queries
- [x] make configurable
- [x] lint fields, named_nodes, anonymous_nodes
- [x] make it work on playground query buffer
