### PR TITLE
fix(linter): Add (grouping) to toplevel-queries

### DIFF
--- a/queries/query/query-linter-queries.scm
+++ b/queries/query/query-linter-queries.scm
@@ -1,4 +1,4 @@
-(program [(named_node) (list)] @toplevel-query)
+(program [(named_node) (list) (grouping)] @toplevel-query)
 (named_node
    name: (identifier) @named_node)
 (ERROR) @error


### PR DESCRIPTION
This lints also top-level queries like:

```scheme
((foo))
```