### PR TITLE
Option to show unnamed nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ require "nvim-treesitter.configs".setup {
     disable = {},
     updatetime = 25, -- Debounced time for highlighting nodes in the playground from source code
     persist_queries = false -- Whether the query persists across vim sessions
+    unnamed = false, -- Whether to show unnamed nodes by default
   }
 }
 ```
@@ -44,6 +45,7 @@ The tree can be toggled using the command `:TSPlaygroundToggle`.
 
 - `R`: Refreshes the playground view when focused or reloads the query when the query editor is focused.
 - `o`: Toggles the query editor when the playground is focused
+- `u`: Toggles display of unnamed nodes
 - `<cr>`: Go to current node in code buffer
 
 ## Query Linter

--- a/lua/nvim-treesitter-playground.lua
+++ b/lua/nvim-treesitter-playground.lua
@@ -10,7 +10,8 @@ function M.init()
     playground = {
       module_path = "nvim-treesitter-playground.internal",
       updatetime = 25,
-      persist_queries = false
+      persist_queries = false,
+      unnamed = true,
     },
     query_linter = {
       module_path = "nvim-treesitter-playground.query_linter",

--- a/lua/nvim-treesitter-playground/printer.lua
+++ b/lua/nvim-treesitter-playground/printer.lua
@@ -3,43 +3,43 @@ local api = vim.api
 
 local M = {}
 
-local function print_tree(root, results, indent)
+local function print_tree(root, unnamed, results, indent)
   local results = results or { lines = {}, nodes = {} }
   local indentation = indent or ""
 
   for node, field in root:iter_children() do
-    if node:named() then
+    if node:named() or unnamed then
+      local name = node:type()
+      if not node:named() then
+        name = '"' .. name .. '"'
+      end
+
       local line
       if field then
         line = string.format("%s%s: %s [%d, %d] - [%d, %d]",
-          indentation,
-          field,
-          node:type(),
-          node:range())
+          indentation, field, name, node:range())
       else
         line = string.format("%s%s [%d, %d] - [%d, %d]",
-          indentation,
-          node:type(),
-          node:range())
+          indentation, name, node:range())
       end
 
       table.insert(results.lines, line)
       table.insert(results.nodes, node)
 
-      print_tree(node, results, indentation .. "  ")
+      print_tree(node, unnamed, results, indentation .. "  ")
     end
   end
 
   return results
 end
 
-function M.print(bufnr, lang)
+function M.print(bufnr, unnamed, lang)
   local bufnr = bufnr or api.nvim_get_current_buf()
   local parser = parsers.get_parser(bufnr, lang)
 
   if not parser then return end
 
-  return print_tree(parser:parse()[1]:root())
+  return print_tree(parser:parse()[1]:root(), unnamed)
 end
 
 local treesitter_namespace = api.nvim_get_namespaces().treesitter_hl

--- a/syntax/tsplayground.vim
+++ b/syntax/tsplayground.vim
@@ -6,10 +6,12 @@ syn match nodeType "[a-zA-Z_]\+"
 syn match nodeNumber "\d\+"
 syn match nodeOp "[,\-\)]\+"
 syn match nodeTag "\k\+:"
+syn match nodeUnnamed "\"[^\"]\+\""
 
 hi def link nodeType Identifier
 hi def link nodeNumber Number
 hi def link nodeOp Operator
 hi def link nodeTag Tag
+hi def link nodeUnnamed String
 
 let b:current_syntax = 'tsplayground'


### PR DESCRIPTION
This is a small feature that maps `u` to toggle displaying of unnamed nodes. Unnamed nodes are shown as strings (wrapped in `"`). This is not a big feature but it might be helpful sometimes.

Example:
![playground_unnamed_nodes](https://user-images.githubusercontent.com/16623787/103825623-763c6f80-5075-11eb-9089-8b52753fab11.png)
