### PR TITLE
refactor(printer): integrate injected languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ The tree can be toggled using the command `:TSPlaygroundToggle`.
 ### Keybindings
 
 - `R`: Refreshes the playground view when focused or reloads the query when the query editor is focused.
-- `o`: Toggles the query editor when the playground is focused
+- `o`: Toggles the query editor when the playground is focused.
+- `a`: Toggles visibility of anonymous nodes.
+- `i`: Toggles visibility of highlight groups.
+- `I`: Toggles visibility of the language the node belongs to.
+- `t`: Toggles visibility of injected languages.
+- `f`: Focuses the language tree under the cursor in the playground. The query editor will now be using the focused language.
+- `F`: Unfocuses the currently focused language.
 - `<cr>`: Go to current node in code buffer
 
 ## Query Linter
@@ -61,6 +67,3 @@ require "nvim-treesitter.configs".setup {
 ```
 
 ![image](https://user-images.githubusercontent.com/7189118/101246661-06089a00-3715-11eb-9c57-6d6439defbf8.png)
-
-# Roadmap
-  - [ ] Add interactive query highlighting

--- a/lua/nvim-treesitter-playground.lua
+++ b/lua/nvim-treesitter-playground.lua
@@ -1,10 +1,6 @@
 local parsers = require 'nvim-treesitter.parsers'
 local M = {}
 
-vim.cmd [[
-  command! TSHighlightCapturesUnderCursor :lua require'nvim-treesitter-playground.hl-info'.show_hl_captures()<cr>
-]]
-
 function M.init()
   require "nvim-treesitter".define_modules {
     playground = {
@@ -21,6 +17,10 @@ function M.init()
       end,
     },
   }
+
+  vim.cmd [[
+    command! TSHighlightCapturesUnderCursor :lua require'nvim-treesitter-playground.hl-info'.show_hl_captures()<cr>
+  ]]
 end
 
 return M

--- a/lua/nvim-treesitter-playground/hl-info.lua
+++ b/lua/nvim-treesitter-playground/hl-info.lua
@@ -18,18 +18,22 @@ function M.show_hl_captures()
   local parser = parsers.get_parser(bufnr, lang)
   if not parser then return function() end end
 
-  local root = parser:parse()[1]:root()
-  if not root then return end
-  local start_row, _, end_row, _ = root:range()
+  parser = parser:language_for_range({row, col, row, col})
 
   local matches = {}
-  local query = queries.get_query(lang, 'highlights')
-  for _, match in query:iter_matches(root, bufnr, start_row, end_row) do
-    for id, node in pairs(match) do
-      if ts_utils.is_in_node_range(node, row, col) then
-        local c = query.captures[id] -- name of the capture in the query
-        if c ~= nil then
-          table.insert(matches, '@'..c..' -> '..(hlmap[c] or 'nil'))
+  local query = queries.get_query(parser:lang(), 'highlights')
+
+  for _, tree in ipairs(parser:trees()) do
+    local root = tree:root()
+    local start_row, _, end_row, _ = root:range()
+
+    for _, match in query:iter_matches(root, bufnr, start_row, end_row) do
+      for id, node in pairs(match) do
+        if ts_utils.is_in_node_range(node, row, col) then
+          local c = query.captures[id] -- name of the capture in the query
+          if c ~= nil then
+            table.insert(matches, '@'..c..' -> '..(hlmap[c] or 'nil'))
+          end
         end
       end
     end

--- a/lua/nvim-treesitter-playground/printer.lua
+++ b/lua/nvim-treesitter-playground/printer.lua
@@ -2,92 +2,191 @@ local parsers = require 'nvim-treesitter.parsers'
 local api = vim.api
 
 local M = {}
+local treesitter_namespace = api.nvim_get_namespaces()["treesitter/highlighter"]
+local virt_text_id = api.nvim_create_namespace('TSPlaygroundHlGroups')
+local lang_virt_text_id = api.nvim_create_namespace('TSPlaygroundLangGroups')
 
-local function print_tree(root, results, indent)
-  local results = results or { lines = {}, nodes = {} }
-  local indentation = indent or ""
+local function get_extmarks(bufnr, start, end_)
+  return api.nvim_buf_get_extmarks(bufnr, treesitter_namespace, start, end_, { details = true })
+end
+
+local function get_hl_group_for_node(bufnr, node)
+  local start_row, start_col, end_row, end_col = node:range()
+  local extmarks = get_extmarks(bufnr, {start_row, start_col}, {end_row, end_col})
+  local groups = {}
+
+  if #extmarks > 0 then
+    for _, ext in ipairs(extmarks) do
+      table.insert(groups, ext[4].hl_group)
+    end
+  end
+
+  return groups
+end
+
+local function flatten_node(root, results, level, language_tree, options)
+  level = level or 0
+  results = results or {}
 
   for node, field in root:iter_children() do
-    if node:named() then
-      local line
-      if field then
-        line = string.format("%s%s: %s [%d, %d] - [%d, %d]",
-          indentation,
-          field,
-          node:type(),
-          node:range())
-      else
-        line = string.format("%s%s [%d, %d] - [%d, %d]",
-          indentation,
-          node:type(),
-          node:range())
-      end
+    if node:named() or options.include_anonymous_nodes then
+      local node_entry = {
+        level = level,
+        node = node,
+        field = field,
+        language_tree = language_tree,
+        hl_groups = options.include_hl_groups
+          and options.bufnr
+          and get_hl_group_for_node(options.bufnr, node)
+          or {}
+      }
 
-      table.insert(results.lines, line)
-      table.insert(results.nodes, node)
+      table.insert(results, node_entry)
 
-      print_tree(node, results, indentation .. "  ")
+      flatten_node(node, results, level + 1, language_tree, options)
     end
   end
 
   return results
 end
 
-function M.print(bufnr, lang)
-  local bufnr = bufnr or api.nvim_get_current_buf()
-  local parser = parsers.get_parser(bufnr, lang)
+local function node_contains(node, range)
+  local start_row, start_col, end_row, end_col = node:range()
+  local start_fits = start_row < range[1] or (start_row == range[1] and start_col <= range[2])
+  local end_fits = end_row > range[3] or (end_row == range[3] and end_col >= range[4])
 
-  if not parser then return end
-
-  return print_tree(parser:parse()[1]:root())
+  return start_fits and end_fits
 end
 
-local treesitter_namespace = api.nvim_get_namespaces().treesitter_hl
-local virt_text_id = api.nvim_create_namespace('TSPlaygroundHlGroups')
+local function flatten_lang_tree(lang_tree, results, options)
+  results = results or {}
 
-local function get_extmarks(bufnr, start, end_)
-  return api.nvim_buf_get_extmarks(bufnr, treesitter_namespace, start, end_, { details = true })
-end
+  for _, tree in ipairs(lang_tree:trees()) do
+    local root = tree:root()
+    local head_entry = nil
+    local head_entry_index = nil
 
-function M.print_hl_groups(bufnr, display_bufnr, lang)
-  local bufnr = bufnr or api.nvim_get_current_buf()
-  local parser = parsers.get_parser(bufnr, lang)
+    for i, node_entry in ipairs(results) do
+      local is_contained = node_contains(node_entry.node, {root:range()})
 
-  if not parser then return end
-
-  local i = 0
-  local function iter(root)
-    for node, _ in root:iter_children() do
-      if node:named() then
-        local start_row, start_col, end_row, end_col = node:range()
-        local extmarks = get_extmarks(bufnr, {start_row, start_col}, {end_row, end_col})
-
-        if #extmarks > 0 then
-          local groups = {}
-
-          for idx, ext in ipairs(extmarks) do
-            local infos = ext[4]
-            local hl_group = infos.hl_group
-            local str = hl_group.." / "
-            if idx == #extmarks then
-              str = str:sub(0, -3)
-            end
-            table.insert(groups, {str, hl_group})
+      if is_contained then
+        if not head_entry then
+          head_entry = node_entry
+          head_entry_index = i
+        else
+          if node_entry.level >= head_entry.level then
+            head_entry = node_entry
+            head_entry_index = i
+          else
+            -- If entry contains the root tree but is less specific, then we
+            -- can exit the loop
+            break
           end
-          api.nvim_buf_set_virtual_text(display_bufnr, virt_text_id, i, groups, {})
         end
-
-        i = i + 1
-        iter(node)
       end
+    end
+
+    local insert_index = head_entry_index and head_entry_index or #results
+    local level = head_entry and head_entry.level + 1 or nil
+
+    local flattened_root = flatten_node(root, nil, level, lang_tree, options)
+    local i = insert_index + 1
+
+    -- Insert new items into the table at the correct positions
+    for _, entry in ipairs(flattened_root) do
+      table.insert(results, i, entry)
+      i = i + 1
     end
   end
 
-  iter(parser:parse()[1]:root())
+  if not options.suppress_injected_languages then
+    for _, child in pairs(lang_tree:children()) do
+      flatten_lang_tree(child, results, options)
+    end
+  end
+
+  return results
+end
+
+function M.process(bufnr, lang_tree, options)
+  bufnr = bufnr or api.nvim_get_current_buf()
+  options = options or {}
+  lang_tree = lang_tree or parsers.get_parser(bufnr)
+  options.bufnr = options.bufnr or bufnr
+
+  if not lang_tree then return {} end
+
+  return flatten_lang_tree(lang_tree, nil, options)
+end
+
+function M.print_entry(node_entry)
+  local line
+  local indent = string.rep("  ", node_entry.level)
+  local node = node_entry.node
+  local field = node_entry.field
+  local node_name = node:type()
+
+  if not node:named() then
+    node_name = string.format([["%s"]], node_name)
+    node_name = string.gsub(node_name, "\n", "\\n")
+  end
+
+  if field then
+    line = string.format("%s%s: %s [%d, %d] - [%d, %d]",
+      indent,
+      field,
+      node_name,
+      node:range())
+  else
+    line = string.format("%s%s [%d, %d] - [%d, %d]",
+      indent,
+      node_name,
+      node:range())
+  end
+
+  return line
+end
+
+function M.print_entries(node_entries)
+  local results = {}
+
+  for _, entry in ipairs(node_entries) do
+    table.insert(results, M.print_entry(entry))
+  end
+
+  return results
+end
+
+function M.print_hl_groups(bufnr, node_entries)
+  for i, node_entry in ipairs(node_entries) do
+    local groups = {}
+
+    for j, hl_group in ipairs(node_entry.hl_groups) do
+      local str = hl_group .. " / "
+
+      if j == #hl_group then
+        str = string.sub(str, 0, -3)
+      end
+
+      table.insert(groups, {str, hl_group})
+    end
+
+    api.nvim_buf_set_virtual_text(bufnr, virt_text_id, i, groups, {})
+  end
+end
+
+function M.print_language(bufnr, node_entries)
+  for i, node_entry in ipairs(node_entries) do
+    api.nvim_buf_set_virtual_text(bufnr, lang_virt_text_id, i - 1, {{node_entry.language_tree:lang()}}, {})
+  end
 end
 
 function M.remove_hl_groups(bufnr)
   api.nvim_buf_clear_namespace(bufnr, virt_text_id, 0, -1)
+end
+
+function M.remove_language(bufnr)
+  api.nvim_buf_clear_namespace(bufnr, lang_virt_text_id, 0, -1)
 end
 
 return M

--- a/lua/nvim-treesitter-playground/query.lua
+++ b/lua/nvim-treesitter-playground/query.lua
@@ -1,25 +1,29 @@
 local ts_query = require 'nvim-treesitter.query'
 local parsers = require 'nvim-treesitter.parsers'
 local locals = require 'nvim-treesitter.locals'
-local api = vim.api
 
 local M = {}
 
-function M.parse(bufnr, query)
-  local lang = api.nvim_buf_get_option(bufnr, 'ft')
-  local success, parsed_query = pcall(function() return vim.treesitter.parse_query(lang, query) end)
+function M.parse(bufnr, query, lang_tree)
+  lang_tree = lang_tree or parsers.get_parser(bufnr)
+
+  local success, parsed_query = pcall(function()
+    return vim.treesitter.parse_query(lang_tree:lang(), query)
+  end)
 
   if not success then return {} end
 
-  local parser = parsers.get_parser(bufnr, lang)
-  local root = parser:parse()[1]:root()
-  local start_row, _, end_row, _ = root:range()
   local results = {}
 
-  for match in ts_query.iter_prepared_matches(parsed_query, root, bufnr, start_row, end_row) do
-    locals.recurse_local_nodes(match, function(_, node, path)
-      table.insert(results, { node = node, tag = path })
-    end)
+  for _, tree in ipairs(lang_tree:trees()) do
+    local root = tree:root()
+    local start_row, _, end_row, _ = root:range()
+
+    for match in ts_query.iter_prepared_matches(parsed_query, root, bufnr, start_row, end_row) do
+      locals.recurse_local_nodes(match, function(_, node, path)
+        table.insert(results, { node = node, tag = path })
+      end)
+    end
   end
 
   return results

--- a/lua/nvim-treesitter-playground/utils.lua
+++ b/lua/nvim-treesitter-playground/utils.lua
@@ -24,4 +24,20 @@ function M.for_each_buf_window(bufnr, fn)
   end
 end
 
+function M.to_lookup_table(list, key_mapper)
+  local result = {}
+
+  for i, v in ipairs(list) do
+    local key = v
+
+    if key_mapper then
+      key = key_mapper(v, i)
+    end
+
+    result[key] = v
+  end
+
+  return result
+end
+
 return M

--- a/plugin/nvim-treesitter-playground.vim
+++ b/plugin/nvim-treesitter-playground.vim
@@ -4,5 +4,6 @@ EOF
 
 highlight default link TSPlaygroundFocus Visual
 highlight default link TSQueryLinterError Error
+highlight default link TSPlaygroundLang String
 
 command! TSPlaygroundToggle lua require "nvim-treesitter-playground.internal".toggle()

--- a/syntax/tsplayground.vim
+++ b/syntax/tsplayground.vim
@@ -6,10 +6,12 @@ syn match nodeType "[a-zA-Z_]\+"
 syn match nodeNumber "\d\+"
 syn match nodeOp "[,\-\)]\+"
 syn match nodeTag "\k\+:"
+syn match nodeAnonymous "\".\+\""
 
 hi def link nodeType Identifier
 hi def link nodeNumber Number
 hi def link nodeOp Operator
 hi def link nodeTag Tag
+hi def link nodeAnonymous String
 
 let b:current_syntax = 'tsplayground'


### PR DESCRIPTION
This integrates injected languages into the playground. It adds new features as well.

- Toggle display of the language that the node belongs to
- Toggle display of anonymous nodes
- Nested languages can be "focused". The query editor will run queries on the focused language tree. It is not possible to run queries across multiple languages.
- Toggle display of injected languages. This will turn off processing for injected languages.
- Various bug fixes