### PR TITLE
fix: unescape anonymous nodes with escape sequences

### DIFF
--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -93,7 +93,7 @@ function M.lint(query_buf)
         local node_type = ts_utils.get_node_text(node)[1]
 
         if anonymous_node then
-          node_type = node_type:gsub('"(.*)".*$', "%1")
+          node_type = node_type:gsub('"(.*)".*$', "%1"):gsub('\\(.)', '%1')
         end
 
         local is_named = named_node ~= nil


### PR DESCRIPTION
This will enable the linter to recognize LaTeX commands like
`\usepackage` though it will appear as `"\\usepackage"` in the
query files.