### PR TITLE
Avoid crash: check if the buffer is loaded before calling win_findbuf

### DIFF
--- a/lua/nvim-treesitter-playground/utils.lua
+++ b/lua/nvim-treesitter-playground/utils.lua
@@ -1,3 +1,5 @@
+local api = vim.api
+
 local M = {}
 
 function M.debounce(fn, debounce_time)
@@ -25,6 +27,10 @@ function M.debounce(fn, debounce_time)
 end
 
 function M.for_each_buf_window(bufnr, fn)
+  if not api.nvim_buf_is_loaded(bufnr) then
+    return
+  end
+
   for _, window in ipairs(vim.fn.win_findbuf(bufnr)) do
     fn(window)
   end


### PR DESCRIPTION
Closes https://github.com/nvim-treesitter/playground/issues/33

We should report this to neovim as well (https://github.com/neovim/neovim/issues/14998)