### PR TITLE
Playground: check for nodes out of range (EOF)

### DIFF
--- a/lua/nvim-treesitter-playground/internal.lua
+++ b/lua/nvim-treesitter-playground/internal.lua
@@ -450,6 +450,13 @@ function M.highlight_node(bufnr)
   end
 
   local start_row, start_col, _ = node:start()
+  local last_row, last_col = utils.get_end_pos(bufnr)
+  -- Set the cursor to the last column
+  -- if the node starts at the EOF mark.
+  if start_row > last_row then
+    start_row = last_row
+    start_col = last_col
+  end
 
   M.highlight_nodes(bufnr, { node })
 

--- a/lua/nvim-treesitter-playground/utils.lua
+++ b/lua/nvim-treesitter-playground/utils.lua
@@ -60,4 +60,13 @@ function M.node_contains(node, range)
   return start_fits and end_fits
 end
 
+--- Returns a tuple with the position of the last line and last column (0-indexed).
+function M.get_end_pos(bufnr)
+  local bufnr = bufnr or api.nvim_get_current_buf()
+  local last_row = api.nvim_buf_line_count(bufnr) - 1
+  local last_line = api.nvim_buf_get_lines(bufnr, last_row, last_row + 1, true)[1]
+  local last_col = #last_line
+  return last_row, last_col
+end
+
 return M


### PR DESCRIPTION
The playground will try to set the cursor
to an invalid position (nvim_win_set_cursor) if the node starts at the EOF mark.

```ruby
def run
  a = <<~EOF
end
```

found this while debugging https://github.com/nvim-treesitter/nvim-treesitter/issues/1531