### PR TITLE
playground keybindings no longer recursive, fixes #52

### DIFF
--- a/lua/nvim-treesitter-playground/internal.lua
+++ b/lua/nvim-treesitter-playground/internal.lua
@@ -212,7 +212,7 @@ local function setup_buf(for_buf)
       "n",
       mapping,
       string.format(':lua require "nvim-treesitter-playground.internal".%s(%d)<CR>', func, for_buf),
-      { silent = true }
+      { silent = true, noremap = true }
     )
   end
   api.nvim_buf_attach(buf, false, {


### PR DESCRIPTION
Tiny edit to fix keybinds not working when used with some vim config mappings, see issue #52. Credit goes to @waldson for finding the fix :+1: 