### PR TITLE
Fix 'Show Highlights' in TSPlayground

### DIFF
--- a/lua/nvim-treesitter-playground/hl-info.lua
+++ b/lua/nvim-treesitter-playground/hl-info.lua
@@ -1,4 +1,4 @@
-local utils = require 'nvim-treesitter-playground.utils'
+local utils = require "nvim-treesitter-playground.utils"
 local highlighter = require "vim.treesitter.highlighter"
 
 local M = {}

--- a/lua/nvim-treesitter-playground/printer.lua
+++ b/lua/nvim-treesitter-playground/printer.lua
@@ -3,22 +3,17 @@ local utils = require "nvim-treesitter-playground.utils"
 local api = vim.api
 
 local M = {}
-local treesitter_namespace = api.nvim_get_namespaces()["treesitter/highlighter"]
 local virt_text_id = api.nvim_create_namespace "TSPlaygroundHlGroups"
 local lang_virt_text_id = api.nvim_create_namespace "TSPlaygroundLangGroups"
 
-local function get_extmarks(bufnr, start, end_)
-  return api.nvim_buf_get_extmarks(bufnr, treesitter_namespace, start, end_, { details = true })
-end
-
 local function get_hl_group_for_node(bufnr, node)
-  local start_row, start_col, end_row, end_col = node:range()
-  local extmarks = get_extmarks(bufnr, { start_row, start_col }, { end_row, end_col })
+  local start_row, start_col, _, _ = node:range()
+  local extmarks = utils.get_hl_groups_at_position(bufnr, start_row, start_col )
   local groups = {}
 
   if #extmarks > 0 then
-    for _, ext in ipairs(extmarks) do
-      table.insert(groups, ext[4].hl_group)
+    for _, ext in pairs(extmarks) do
+      table.insert(groups, ext)
     end
   end
 
@@ -29,6 +24,7 @@ local function flatten_node(root, results, level, language_tree, options)
   level = level or 0
   results = results or {}
 
+
   for node, field in root:iter_children() do
     if node:named() or options.include_anonymous_nodes then
       local node_entry = {
@@ -36,7 +32,7 @@ local function flatten_node(root, results, level, language_tree, options)
         node = node,
         field = field,
         language_tree = language_tree,
-        hl_groups = options.include_hl_groups and options.bufnr and get_hl_group_for_node(options.bufnr, node) or {},
+        hl_groups = options.include_hl_groups and options.bufnr and get_hl_group_for_node(options.bufnr, node) or {}
       }
 
       table.insert(results, node_entry)

--- a/lua/nvim-treesitter-playground/printer.lua
+++ b/lua/nvim-treesitter-playground/printer.lua
@@ -8,7 +8,7 @@ local lang_virt_text_id = api.nvim_create_namespace "TSPlaygroundLangGroups"
 
 local function get_hl_group_for_node(bufnr, node)
   local start_row, start_col, _, _ = node:range()
-  local extmarks = utils.get_hl_groups_at_position(bufnr, start_row, start_col )
+  local extmarks = utils.get_hl_groups_at_position(bufnr, start_row, start_col)
   local groups = {}
 
   if #extmarks > 0 then
@@ -24,7 +24,6 @@ local function flatten_node(root, results, level, language_tree, options)
   level = level or 0
   results = results or {}
 
-
   for node, field in root:iter_children() do
     if node:named() or options.include_anonymous_nodes then
       local node_entry = {
@@ -32,7 +31,7 @@ local function flatten_node(root, results, level, language_tree, options)
         node = node,
         field = field,
         language_tree = language_tree,
-        hl_groups = options.include_hl_groups and options.bufnr and get_hl_group_for_node(options.bufnr, node) or {}
+        hl_groups = options.include_hl_groups and options.bufnr and get_hl_group_for_node(options.bufnr, node) or {},
       }
 
       table.insert(results, node_entry)

--- a/lua/nvim-treesitter-playground/utils.lua
+++ b/lua/nvim-treesitter-playground/utils.lua
@@ -1,4 +1,6 @@
 local api = vim.api
+local ts_utils = require "nvim-treesitter.ts_utils"
+local highlighter = require "vim.treesitter.highlighter"
 
 local M = {}
 
@@ -24,6 +26,56 @@ function M.debounce(fn, debounce_time)
       end)
     )
   end
+end
+
+function M.get_hl_groups_at_position(bufnr, row, col)
+  local buf_highlighter = highlighter.active[bufnr]
+
+  if not buf_highlighter then
+    return {}
+  end
+
+  local matches = {}
+
+  buf_highlighter.tree:for_each_tree(function(tstree, tree)
+    if not tstree then
+      return
+    end
+
+    local root = tstree:root()
+    local root_start_row, _, root_end_row, _ = root:range()
+
+    -- Only worry about trees within the line range
+    if root_start_row > row or root_end_row < row then
+      return
+    end
+
+    local query = buf_highlighter:get_query(tree:lang())
+
+    -- Some injected languages may not have highlight queries.
+    if not query:query() then
+      return
+    end
+
+    local iter = query:query():iter_captures(root, buf_highlighter.bufnr, row, row + 1)
+
+    for capture, node in iter do
+      local hl = query.hl_cache[capture]
+
+      if hl and ts_utils.is_in_node_range(node, row, col) then
+        local c = query._query.captures[capture] -- name of the capture in the query
+        if c ~= nil then
+          local general_hl = query:_get_hl_from_capture(capture)
+          if general_hl ~= 0 then
+            table.insert(matches, general_hl)
+          else
+            table.insert(matches, c)
+          end
+        end
+      end
+    end
+  end, true)
+  return matches
 end
 
 function M.for_each_buf_window(bufnr, fn)


### PR DESCRIPTION
The extmarks used to highlight syntax with tree-sitter are "ephemeral" and so can't be fetched with `nvim_buf_get_extmarks` - Instead, we need to execute the query against the document and get the highlighted node ranges (exactly like is done for TSHighlightCapturesUnderCursor)

This restores the functionality of showing the highlight groups for a given treesitter node by pressing "i" (or whatever) in the playground - a super handy function.

NB:  If I run this on the `printer.lua` file it gets "off" by about the 10th line

![Screen Shot 2021-11-11 at 2 20 49 PM](https://user-images.githubusercontent.com/149870/141377435-49d3ffc0-0a81-4f26-9547-1cbe74a22110.png)
![Screen Shot 2021-11-11 at 2 22 22 PM](https://user-images.githubusercontent.com/149870/141377481-a54798e2-c9eb-4daa-9173-c1ae2279e41a.png)

Obviously, the `=` there is properly highlighted as an operator, so I'm not really sure what's going on there - `TSHighlightCapturesUnderCursor` show the correct group.
