### PR TITLE
Fix local hl on `:TSHighlightCapturesUnderCursor`

### DIFF
--- a/lua/nvim-treesitter-playground/hl-info.lua
+++ b/lua/nvim-treesitter-playground/hl-info.lua
@@ -39,14 +39,16 @@ function M.get_treesitter_hl()
     local iter = query:query():iter_captures(root, self.bufnr, row, row + 1)
 
     for capture, node, metadata in iter do
-      local hl = query.hl_cache[capture]
-
-      if hl and ts_utils.is_in_node_range(node, row, col) then
+      if ts_utils.is_in_node_range(node, row, col) then
         local c = query._query.captures[capture] -- name of the capture in the query
         if c ~= nil then
-          local general_hl = query:_get_hl_from_capture(capture)
-          local line = "* **@" .. c .. "** -> " .. hl
-          if general_hl ~= hl then
+          local general_hl, is_vim_hl = query:_get_hl_from_capture(capture)
+          local local_hl = not is_vim_hl and (tree:lang() .. general_hl)
+          local line = "* **@" .. c .. "**"
+          if local_hl then
+            line = line .. " -> **" .. local_hl .. "**"
+          end
+          if general_hl then
             line = line .. " -> **" .. general_hl .. "**"
           end
           if metadata.priority then


### PR DESCRIPTION
This code depended on an internal cache that stored the names,
but it was changed to store the id https://github.com/neovim/neovim/commit/2460f0a7028550ea2d87492a4e8b95914fdba7b1.

There is `nvim_get_hl_by_id`, but that doesn't return the name (just the
final values of the colors). So, I'm just duplicating this part https://github.com/neovim/neovim/blob/6a92a53c02c429630c4b961e51dc97f3354ea196/runtime/lua/vim/treesitter/highlighter.lua#L81-L93

Fixes https://github.com/nvim-treesitter/playground/issues/60