### PR TITLE
feat!: update to Neovim 0.7 APIs

### DIFF
--- a/lua/nvim-treesitter-playground.lua
+++ b/lua/nvim-treesitter-playground.lua
@@ -29,13 +29,6 @@ function M.init()
       end,
     },
   }
-
-  vim.cmd [[
-    command! TSHighlightCapturesUnderCursor :lua require'nvim-treesitter-playground.hl-info'.show_hl_captures()<cr>
-  ]]
-  vim.cmd [[
-    command! TSNodeUnderCursor :lua require'nvim-treesitter-playground.hl-info'.show_ts_node()<cr>
-  ]]
 end
 
 return M

--- a/lua/nvim-treesitter-playground/hl-info.lua
+++ b/lua/nvim-treesitter-playground/hl-info.lua
@@ -158,21 +158,18 @@ function M.show_ts_node(opts)
     lines[#lines + 1] = "* Node not found"
   end
 
-  local ns = vim.api.nvim_create_namespace "nvim-treesitter-current-node"
-
   if opts.highlight_node and node_under_cursor then
+    local ns = vim.api.nvim_create_namespace "nvim-treesitter-current-node"
+
     ts_utils.highlight_node(node_under_cursor, bufnr, ns, opts.hl_group)
-    vim.cmd(string.format(
-      [[
-      augroup TreesitterNodeUnderCursor
-      au!
-      autocmd CursorMoved <buffer=%d> lua require'nvim-treesitter-playground.internal'.clear_highlights(%d, %d)
-      augroup END
-    ]],
-      bufnr,
-      bufnr,
-      ns
-    ))
+    vim.api.nvim_create_autocmd("CursorMoved", {
+      group = vim.api.nvim_create_augroup("TSNodeUnderCursor", {}),
+      buffer = bufnr,
+      callback = function()
+        require("nvim-treesitter-playground.internal").clear_highlights(bufnr, ns)
+      end,
+      desc = "TSPlayground: clear highlights",
+    })
   end
 
   return vim.lsp.util.open_floating_preview(lines, "markdown", { border = "single", pad_left = 4, pad_right = 4 })

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -139,27 +139,20 @@ function M.attach(buf, _)
   M.use_virtual_text = config.use_virtual_text
   M.lint_events = config.lint_events
 
-  vim.cmd(string.format("augroup TreesitterPlaygroundLint_%d", buf))
-  vim.cmd "au!"
-  for _, e in pairs(M.lint_events) do
-    vim.cmd(
-      string.format(
-        [[autocmd! %s <buffer=%d> lua require'nvim-treesitter-playground.query_linter'.lint(%d)]],
-        e,
-        buf,
-        buf
-      )
-    )
-  end
-  vim.cmd "augroup END"
+  vim.api.nvim_create_autocmd(M.lint_events, {
+    group = vim.api.nvim_create_augroup("TSPlaygroundLint", {}),
+    buffer = buf,
+    callback = function()
+      require("nvim-treesitter-playground.query_linter").lint(buf)
+    end,
+    desc = "TSPlayground: lint query",
+  })
 end
 
 function M.detach(buf)
   M.lints[buf] = nil
   M.clear_virtual_text(buf)
-  for _, e in pairs(M.lint_events) do
-    vim.cmd(string.format("autocmd! TreesitterPlaygroundLint_%d %s", buf, e))
-  end
+  vim.api.nvim_clear_autocmds { group = "TSPlaygroundLint", buffer = buf, event = M.lint_events }
 end
 
 return M

--- a/plugin/nvim-treesitter-playground.lua
+++ b/plugin/nvim-treesitter-playground.lua
@@ -1,0 +1,28 @@
+-- setup playground module
+require("nvim-treesitter-playground").init()
+local api = vim.api
+
+-- define highlights
+local highlights = {
+  TSPlaygroundFocus = { link = "Visual", default = true },
+  TSQueryLinterError = { link = "Error", default = true },
+  TSPlaygroundLang = { link = "String", default = true },
+}
+for k, v in pairs(highlights) do
+  api.nvim_set_hl(0, k, v)
+end
+
+-- define commands
+api.nvim_create_user_command("TSPlaygroundToggle", function()
+  require("nvim-treesitter-playground.internal").toggle()
+end, {})
+api.nvim_create_user_command("TSNodeUnderCursor", function()
+  require("nvim-treesitter-playground.hl-info").show_ts_node()
+end, {})
+api.nvim_create_user_command("TSCaptureUnderCursor", function()
+  require("nvim-treesitter-playground.hl-info").show_hl_captures()
+end, {})
+---@deprecated
+api.nvim_create_user_command("TSHighlightCapturesUnderCursor", function()
+  require("nvim-treesitter-playground.hl-info").show_hl_captures()
+end, {})

--- a/plugin/nvim-treesitter-playground.vim
+++ b/plugin/nvim-treesitter-playground.vim
@@ -1,9 +1,0 @@
-lua << EOF
-require "nvim-treesitter-playground".init()
-EOF
-
-highlight default link TSPlaygroundFocus Visual
-highlight default link TSQueryLinterError Error
-highlight default link TSPlaygroundLang String
-
-command! TSPlaygroundToggle lua require "nvim-treesitter-playground.internal".toggle()


### PR DESCRIPTION
I would appreciate some testing for regressions since I don't use nearly all features of the Playground (in particular, the query editor and linter).

I could not remove all legacy vimscript since the keymappings are created using string munging, and Lua doesn't have a macro system that would allow similar things natively:
https://github.com/nvim-treesitter/playground/blob/13e2d2d63ce7bc5d875e8bdf89cb070bc8cc7a00/lua/nvim-treesitter-playground/internal.lua#L214
