### PR TITLE
fix: regression in nvim-treesitter/playground#75

### DIFF
--- a/lua/nvim-treesitter-playground/internal.lua
+++ b/lua/nvim-treesitter-playground/internal.lua
@@ -268,14 +268,19 @@ local function setup_query_editor(bufnr)
     desc = "TSPlayground: on query cursor move",
   })
 
-  api.nvim_buf_set_keymap(buf, "n", "R", {
-    silent = true,
-    noremap = true,
-    callback = function()
-      require("nvim-treesitter-playground.internal").update_query(bufnr, buf)
-    end,
-    desc = "TSPlayground: update query",
-  })
+  api.nvim_buf_set_keymap(buf,
+    "n",
+    "R",
+    string.format(':lua require "nvim-treesitter-playground.internal".update_query(%d, %d)<CR>', bufnr, buf),
+    {
+      silent = true,
+      noremap = true,
+      callback = function()
+        require("nvim-treesitter-playground.internal").update_query(bufnr, buf)
+      end,
+      desc = "TSPlayground: update query",
+    }
+  )
 
   api.nvim_buf_attach(buf, false, {
     on_lines = utils.debounce(function()


### PR DESCRIPTION
There was a regression in https://github.com/nvim-treesitter/playground/pull/75 which missed adding the actual method call for an `nvim_buf_set_keymap` call. This simply puts it back.
<img width="1668" alt="Screen Shot 2022-05-01 at 11 51 26 AM" src="https://user-images.githubusercontent.com/2898615/166158144-5ccb2e01-144c-4242-be83-76f67f373f61.png">

