### PR TITLE
fix: adapt to breaking change on master

### DIFF
--- a/lua/nvim-treesitter-playground/utils.lua
+++ b/lua/nvim-treesitter-playground/utils.lua
@@ -65,7 +65,7 @@ function M.get_hl_groups_at_position(bufnr, row, col)
       if hl and ts_utils.is_in_node_range(node, row, col) then
         local c = query._query.captures[capture] -- name of the capture in the query
         if c ~= nil then
-          local general_hl, is_vim_hl = query:_get_hl_from_capture(capture)
+          local general_hl, is_vim_hl = c, false
           local local_hl = not is_vim_hl and (tree:lang() .. general_hl)
           table.insert(
             matches,


### PR DESCRIPTION
This is a stop-gap fix to avoid errors on latest master after https://github.com/neovim/neovim/pull/19931

Closes #89 

This at least gives useful information (the capture name, albeit without leading `@`), but a full rewrite is needed once nvim-treesitter decides on how to handle the upstream changes to highlight group names. 

Chances are the whole functionality can be removed after 0.8 is released.

