### PR TITLE
fix: properly display highlight group information

### DIFF
--- a/lua/nvim-treesitter-playground/hl-info.lua
+++ b/lua/nvim-treesitter-playground/hl-info.lua
@@ -110,20 +110,19 @@ function M.show_ts_node(opts)
   end
 
   local cursor = vim.api.nvim_win_get_cursor(0)
-  local line = cursor[1] - 1
-  local col = cursor[2]
+  local range = { cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2] }
 
   local bufnr = 0
   local root_lang_tree = parsers.get_parser(bufnr)
-  local lang_tree = root_lang_tree:language_for_range { line, col, line, col }
+  local lang_tree = root_lang_tree:language_for_range(range)
 
   local lines = { "# Treesitter" }
   local node_under_cursor
 
   for _, tree in ipairs(lang_tree:trees()) do
     local root = tree:root()
-    if root and ts_utils.is_in_node_range(root, line, col) then
-      local node = root:named_descendant_for_range(line, col, line, col)
+    if root and utils.range_contains({ root:range() }, range) then
+      local node = root:named_descendant_for_range(range[1], range[2], range[3], range[4])
       local path = opts.full_path and get_full_path(node) or node:type()
 
       node_under_cursor = node
@@ -134,7 +133,7 @@ function M.show_ts_node(opts)
       })
 
       if opts.include_anonymous then
-        local anonymous_node = root:descendant_for_range(line, col, line, col)
+        local anonymous_node = root:descendant_for_range(range[1], range[2], range[3], range[4])
         vim.list_extend(lines, {
           " - Anonymous: " .. anonymous_node:type(),
         })

--- a/lua/nvim-treesitter-playground/hl-info.lua
+++ b/lua/nvim-treesitter-playground/hl-info.lua
@@ -7,15 +7,15 @@ local M = {}
 
 function M.get_treesitter_hl()
   local bufnr = vim.api.nvim_get_current_buf()
-  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
-  row = row - 1
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local range = { cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2] }
 
-  local results = utils.get_hl_groups_at_position(bufnr, row, col)
+  local results = utils.get_hl_groups_for_range(bufnr, range)
   local highlights = {}
   for _, hl in pairs(results) do
-    local line = "* **@" .. hl.capture .. "**"
-    if hl.priority then
-      line = line .. "(" .. hl.priority .. ")"
+    local line = "* **@" .. hl.capture_name .. "**"
+    if hl.capture_metadata.priority then
+      line = line .. "(" .. hl.capture_metadata.priority .. ")"
     end
     table.insert(highlights, line)
   end

--- a/lua/nvim-treesitter-playground/printer.lua
+++ b/lua/nvim-treesitter-playground/printer.lua
@@ -151,7 +151,7 @@ function M.print_hl_groups(bufnr, node_entries)
       table.insert(groups, { str, hl_group })
     end
 
-    api.nvim_buf_set_extmark(bufnr, virt_text_id, i, 0, { virt_text = groups })
+    api.nvim_buf_set_extmark(bufnr, virt_text_id, i - 1, 0, { virt_text = groups })
   end
 end
 

--- a/lua/nvim-treesitter-playground/printer.lua
+++ b/lua/nvim-treesitter-playground/printer.lua
@@ -151,13 +151,19 @@ function M.print_hl_groups(bufnr, node_entries)
       table.insert(groups, { str, hl_group })
     end
 
-    api.nvim_buf_set_virtual_text(bufnr, virt_text_id, i, groups, {})
+    api.nvim_buf_set_extmark(bufnr, virt_text_id, i, 0, { virt_text = groups })
   end
 end
 
 function M.print_language(bufnr, node_entries)
   for i, node_entry in ipairs(node_entries) do
-    api.nvim_buf_set_virtual_text(bufnr, lang_virt_text_id, i - 1, { { node_entry.language_tree:lang() } }, {})
+    api.nvim_buf_set_extmark(
+      bufnr,
+      lang_virt_text_id,
+      i - 1,
+      0,
+      { virt_text = { { node_entry.language_tree:lang() } } }
+    )
   end
 end
 

--- a/lua/nvim-treesitter-playground/printer.lua
+++ b/lua/nvim-treesitter-playground/printer.lua
@@ -135,11 +135,10 @@ function M.print_hl_groups(bufnr, node_entries)
       local hl_group_name = "@" .. hl_group.capture_name
       local str = hl_group_name
 
-      if j ~= #hl_groups then
-        str = str .. " / "
-      end
-
       table.insert(groups, { str, hl_group_name })
+      if j ~= #hl_groups then
+        table.insert(groups, { " / " })
+      end
     end
     api.nvim_buf_set_extmark(bufnr, virt_text_id, i - 1, 0, { virt_text = groups })
   end

--- a/lua/nvim-treesitter-playground/printer.lua
+++ b/lua/nvim-treesitter-playground/printer.lua
@@ -128,19 +128,19 @@ end
 
 function M.print_hl_groups(bufnr, node_entries)
   for i, node_entry in ipairs(node_entries) do
+    local hl_groups = node_entry.hl_groups
+
     local groups = {}
-
-    for j, hl_group in ipairs(node_entry.hl_groups) do
+    for j, hl_group in ipairs(hl_groups) do
       local hl_group_name = "@" .. hl_group.capture_name
-      local str = hl_group_name .. " / "
+      local str = hl_group_name
 
-      if j == #hl_group then
-        str = string.sub(str, 0, -3)
+      if j ~= #hl_groups then
+        str = str .. " / "
       end
 
       table.insert(groups, { str, hl_group_name })
     end
-
     api.nvim_buf_set_extmark(bufnr, virt_text_id, i - 1, 0, { virt_text = groups })
   end
 end

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -24,7 +24,7 @@ local function lint_node(node, buf, error_type, complete_message)
   local error_text = complete_message or error_type .. ": " .. node_text
   local error_range = { node:range() }
   if M.use_virtual_text then
-    api.nvim_buf_set_virtual_text(buf, hl_namespace, error_range[1], { { error_text, ERROR_HL } }, {})
+    api.nvim_buf_set_extmark(buf, hl_namespace, error_range[1], 0, { virt_text = { { error_text, ERROR_HL } } })
   end
   table.insert(M.lints[buf], { type = error_type, range = error_range, message = error_text, node_text = node_text })
 end

--- a/lua/nvim-treesitter-playground/utils.lua
+++ b/lua/nvim-treesitter-playground/utils.lua
@@ -130,6 +130,17 @@ local function for_each_hl_group_for_range(bufnr, range, fn)
   end)
 end
 
+function M.get_hl_groups_for_range(bufnr, range)
+  local matches = {}
+  for_each_hl_group_for_range(bufnr, range, function(c_id, c_node, c_metadata, c_name)
+    table.insert(
+      matches,
+      { capture_id = c_id, capture_name = c_name, capture_node = c_node, capture_metadata = c_metadata }
+    )
+  end)
+  return matches
+end
+
 function M.get_hl_groups_at_position(bufnr, row, col)
   local range = { row, col, row, col }
   local matches = {}

--- a/lua/nvim-treesitter-playground/utils.lua
+++ b/lua/nvim-treesitter-playground/utils.lua
@@ -39,6 +39,29 @@ function M.range_contains(range_1, range_2)
     and (range_1[3] > range_2[3] or (range_1[3] == range_2[3] and range_1[4] >= range_2[4]))
 end
 
+--- Determines if {range_1} intersects (inclusive) {range_2}
+---
+---@param range table
+---@param range table
+---
+---@return boolean True if {range_1} intersects {range_2}
+function M.range_intersects(range_1, range_2)
+  return (
+    range_1[1] < range_2[3]
+    or (
+      range_1[1] == range_2[3]
+      and (range_1[2] < range_2[4] or (range_1[2] == range_2[4] and range_1[4] == range_2[4]))
+    )
+  )
+    and (
+      range_2[1] < range_1[3]
+      or (
+        range_2[1] == range_1[3]
+        and (range_2[2] < range_1[4] or (range_2[2] == range_1[4] and range_2[4] == range_1[4]))
+      )
+    )
+end
+
 function M.get_hl_groups_at_position(bufnr, row, col)
   local buf_highlighter = highlighter.active[bufnr]
 
@@ -55,10 +78,9 @@ function M.get_hl_groups_at_position(bufnr, row, col)
     end
 
     local root = tstree:root()
-    local root_start_row, _, root_end_row, _ = root:range()
 
-    -- Only worry about trees within the line range
-    if root_start_row > range[3] or root_end_row < range[1] then
+    -- Only worry about trees within the range
+    if not M.range_intersects({ root:range() }, range) then
       return
     end
 

--- a/plugin/nvim-treesitter-playground.lua
+++ b/plugin/nvim-treesitter-playground.lua
@@ -15,14 +15,14 @@ end
 -- define commands
 api.nvim_create_user_command("TSPlaygroundToggle", function()
   require("nvim-treesitter-playground.internal").toggle()
-end, {})
+end, { bar = true })
 api.nvim_create_user_command("TSNodeUnderCursor", function()
   require("nvim-treesitter-playground.hl-info").show_ts_node()
-end, {})
+end, { bar = true })
 api.nvim_create_user_command("TSCaptureUnderCursor", function()
   require("nvim-treesitter-playground.hl-info").show_hl_captures()
-end, {})
+end, { bar = true })
 ---@deprecated
 api.nvim_create_user_command("TSHighlightCapturesUnderCursor", function()
   require("nvim-treesitter-playground.hl-info").show_hl_captures()
-end, {})
+end, { bar = true })


### PR DESCRIPTION
This is very much a patch set; you probably don't want to review the merged diff.

All commits have been formatted with `stylua -- .`.

## fix: update to `nvim_buf_set_extmark`

`nvim_buf_set_virtual_text` was deprecated in Neovim v0.6.0.

## fix: properly position highlight group text

Row offsets weren't accounted for.

## feat: support `|:command-bar|` when possible

Ran into the lack of bar support while testing.

## Refactoring commits

These patches are split up for readability. Most of them serve as preparation for the introduction of `utils.get_hl_groups_for_range()`.

### refactor: use `utils.range_contains()`

This function is introduced, which doesn't want the LHS to be a node. Use of this function clarifies that some existing checks use positions as zero-width ranges and that some other functions are able to take full ranges and not just positions.

### perf: use `utils.range_intersects()`

This function is introduced as a companion to `utils.range_contains()`. Use of this function removes the final manual range checking in `utils.get_hl_groups_at_position()`. Use of this function allows for inspecting less trees whenever multiple trees share the same row (`utils.get_hl_groups_for_range()` will now ignore trees that occupy relevant rows but irrelevant columns).

### refactor: use `utils.for_each_hl_tree()`

This function is introduced as a wrapper for `LanguageTree:for_each_tree()`.

### refactor: use `utils.for_each_query_capture_for_range()`

This function is introduced as a companion to `LanguageTree:for_each_tree()`, but instead iterating via `Query:iter_captures()`, mainly to factor out the range checking logic and clean `utils.get_hl_groups_at_position()`'s implementation further.

I think there's potential for better performance by using `utils.for_each_hl_tree()` and `utils.for_each_query_capture_for_range()` more directly in `lua/nvim-treesitter-playground/printer.lua`, but this is left as future work.

### refactor: use `for_each_hl_group_for_range()`

This function is introduced as a private, specialized wrapper for most of `utils.get_hl_groups_at_position()`'s internals, and would not exist if not for the next commit.

## fix: use `utils.get_hl_groups_for_range()`

This function is introduced as a range-based alternative to the position-based `utils.get_hl_groups_at_position()`. `utils.get_hl_groups_at_position()` would be changed to a simple wrapper of `utils.get_hl_groups_for_range()` if not for the slight interface change (returning a table with `capture_id`, `capture_name`, `capture_node`, and `capture_metadata` instead of a table with `capture` (containing the capture ID) and `priority` (containing one piece of information from the capture metadata). This more directly passes through what `Query:iter_captures()` provides. To provide this alternative interface with minimal code duplication, `for_each_hl_group_for_range()` is used. (If `utils.get_hl_groups_at_position()` becomes deprecated and later is removed, `for_each_hl_group_for_range()` should be inlined.)

Additionally, `flatten_node` in `lua/nvim-treesitter-playground/printer.lua` now directly uses `utils.get_hl_groups_for_range()` and avoids an extra iteration over every `hl_group`.

This commit's message follows:

`utils.get_hl_groups_for_range()` requires that highlight groups contain the whole range argument, preventing highlight groups that only occur at the start of a node's range from being reported for the whole node.

Without this patch, for `get_hl_group_for_node`, the playground prints:
```
  parameters: parameters [8, 36] - [8, 49] @variable / @function / @punctuation.bracket /
    "(" [8, 36] - [8, 37] @variable / @function / @punctuation.bracket /
    name: identifier [8, 37] - [8, 42] @punctuation.bracket / @variable / @parameter /
```

With this patch, the playground prints:
```
  parameters: parameters [8, 36] - [8, 49]
    "(" [8, 36] - [8, 37] @punctuation.bracket /
    name: identifier [8, 37] - [8, 42] @variable / @parameter /
```

In this example, `@punctuation.bracket` is no longer incorrectly associated with the `parameters` node, among other corrections.

## fix: properly prevent trailing highlight group separator

As you can see in the previous playground example, trailing separators for highlight group information aren't being handled properly.

## perf: separate highlight group separator virtual text

Avoiding these string concatenations is faster. Additionally, the separator is no longer highlighted.

With anonymous nodes & highlight group information showing in `lua/nvim-treesitter-playground/hl-info.lua`, I experience a noticeable speed-up compared to both the previous commit and `master` when adding and removing spaces in insert mode between `M.show_ts_node` and the directly following `(opts`. It's still laggy on my machine, but it's better. I consider this a performance win for the whole patch set.