### PR TITLE
fix: use current buf for get_node_text in on_query_cursor_move

### DIFF
--- a/lua/nvim-treesitter-playground/internal.lua
+++ b/lua/nvim-treesitter-playground/internal.lua
@@ -581,7 +581,7 @@ function M.on_query_cursor_move(bufnr)
     local _, _, capture_end = capture.def.node:end_()
     local _, _, start = node_at_point:start()
     local _, _, _end = node_at_point:end_()
-    local capture_name = vim.treesitter.query.get_node_text(capture.name.node, bufnr)
+    local capture_name = vim.treesitter.query.get_node_text(capture.name.node, api.nvim_get_current_buf())
 
     if start >= capture_start and _end <= capture_end and capture_name then
       M.highlight_matched_query_nodes_from_capture(bufnr, capture_name)


### PR DESCRIPTION
https://github.com/nvim-treesitter/playground/pull/105 broke highlighting of captures under the cursor in the `query_editor`.

i'm guessing some of the other calls to the upstream `get_node_text` introduced in the pr might have to be adjusted, but i don't the codebase / treesitter well enough to say.