### PR TITLE
Floating window zindex in config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ require "nvim-treesitter.configs".setup {
     disable = {},
     updatetime = 25, -- Debounced time for highlighting nodes in the playground from source code
     persist_queries = false, -- Whether the query persists across vim sessions
+    floating_window_zindex = 200,
     keybindings = {
       toggle_query_editor = 'o',
       toggle_hl_groups = 'i',

--- a/lua/nvim-treesitter-playground.lua
+++ b/lua/nvim-treesitter-playground.lua
@@ -7,6 +7,7 @@ function M.init()
       module_path = "nvim-treesitter-playground.internal",
       updatetime = 25,
       persist_queries = false,
+      floating_window_zindex = 200,
       keybindings = {
         toggle_query_editor = "o",
         toggle_hl_groups = "i",

--- a/lua/nvim-treesitter-playground/hl-info.lua
+++ b/lua/nvim-treesitter-playground/hl-info.lua
@@ -2,8 +2,15 @@ local utils = require "nvim-treesitter-playground.utils"
 local highlighter = require "vim.treesitter.highlighter"
 local ts_utils = require "nvim-treesitter.ts_utils"
 local parsers = require "nvim-treesitter.parsers"
+local configs = require "nvim-treesitter.configs"
 
 local M = {}
+
+local function get_float_zindex()
+  local config = configs.get_module "playground"
+
+  return config and config.floating_window_zindex or 200
+end
 
 function M.get_treesitter_hl()
   local bufnr = vim.api.nvim_get_current_buf()
@@ -67,7 +74,7 @@ function M.show_hl_captures()
     table.insert(result, "* No highlight groups found")
   end
 
-  vim.lsp.util.open_floating_preview(result, "markdown", { border = "single", pad_left = 4, pad_right = 4 })
+  vim.lsp.util.open_floating_preview(result, "markdown", { border = "single", pad_left = 4, pad_right = 4, zindex = get_float_zindex() })
 end
 
 -- Show Node at Cursor
@@ -172,7 +179,7 @@ function M.show_ts_node(opts)
     })
   end
 
-  return vim.lsp.util.open_floating_preview(lines, "markdown", { border = "single", pad_left = 4, pad_right = 4 })
+  return vim.lsp.util.open_floating_preview(lines, "markdown", { border = "single", pad_left = 4, pad_right = 4, zindex = get_float_zindex() })
 end
 
 return M


### PR DESCRIPTION
Hello dear all!
In some cases (e.g. to use TSHighlightCapturesUnderCursor on LSP documentation (which is also in a floating window) we have to specify zindex of the playground's floating window in order to make it on top of the z-buffer.
I'd suggest to specify a `floating_window_zindex` value in the module configuration.
Please take a look at the PR.
Thank you!