### PR TITLE
docs: mention `:TSNodeUnderCursor` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ require "nvim-treesitter.configs".setup {
 
 The playground comes with `:TSHighlightCapturesUnderCursor` that shows any treesitter or syntax highlight groups under the cursor.
 
-![image](https://user-images.githubusercontent.com/292349/119982982-6665ef00-bf74-11eb-93d5-9b214928c3a9.png)
+<img src="https://user-images.githubusercontent.com/292349/119982982-6665ef00-bf74-11eb-93d5-9b214928c3a9.png" width="450">
 
-![image](https://user-images.githubusercontent.com/292349/119983093-8c8b8f00-bf74-11eb-9fa2-3670a8253fbd.png)
+<img src="https://user-images.githubusercontent.com/292349/119983093-8c8b8f00-bf74-11eb-9fa2-3670a8253fbd.png" width="450">
+
+## Show treesitter node under the cursor
+
+If you only wish to view information about the node your cursor is currently on (without having to open up the full tree), you can use `:TSNodeUnderCursor` instead.
+A floating window containing information about the parser, node name and row/col ranges will be shown.
+
+<img src="https://user-images.githubusercontent.com/30731072/210166267-038c529b-f265-4439-8ed8-807b745cf026.png" width="450">


### PR DESCRIPTION
#74 added `:TSNodeUnderCursor`, but this isn't mentioned anywhere on the README. This PR helps to increase visibility of this functionality.


EDIT: oops, just saw #104 plans to remove the two exposed commands. Not sure when `:Inspect` will stabilize, if it is soon, then feel free to close this PR.