### PR TITLE
fix: peacefully ignore query files without a valid language

### DIFF
--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -70,7 +70,9 @@ function M.lint(query_buf)
 
   local ok, parser_info = pcall(vim.treesitter.inspect_language, query_lang)
 
-  parser_info = ok and parser_info
+  if not ok then
+    return
+  end
 
   local matches = queries.get_matches(query_buf, "query-linter-queries")
 


### PR DESCRIPTION
This fixes the error where out-of-tree queries are annotated with errors due to different directory structures

see https://github.com/NixOS/nixpkgs/issues/189838#issuecomment-1380814689

the screenshot in the original comment is from https://github.com/tree-sitter/tree-sitter-scala, and the query file is under a directory named `queries`, which is not a valid language name, and this pull request silently ignores it