### PR TITLE
fix: Rename deprecated `vim.treesitter` calls

### DIFF
--- a/lua/nvim-treesitter-playground/internal.lua
+++ b/lua/nvim-treesitter-playground/internal.lua
@@ -517,7 +517,7 @@ function M.update_query(bufnr, query_bufnr)
   for capture_match in ts_query.iter_group_results(query_bufnr, "captures") do
     table.insert(M._entries[bufnr].captures, capture_match.capture)
 
-    local capture = vim.treesitter.query.get_node_text(capture_match.capture.name.node, query_bufnr)
+    local capture = vim.treesitter.get_node_text(capture_match.capture.name.node, query_bufnr)
 
     if not capture_by_color[capture] then
       capture_by_color[capture] = "TSPlaygroundCapture" .. index
@@ -581,7 +581,7 @@ function M.on_query_cursor_move(bufnr)
     local _, _, capture_end = capture.def.node:end_()
     local _, _, start = node_at_point:start()
     local _, _, _end = node_at_point:end_()
-    local capture_name = vim.treesitter.query.get_node_text(capture.name.node, api.nvim_get_current_buf())
+    local capture_name = vim.treesitter.get_node_text(capture.name.node, api.nvim_get_current_buf())
 
     if start >= capture_start and _end <= capture_end and capture_name then
       M.highlight_matched_query_nodes_from_capture(bufnr, capture_name)

--- a/lua/nvim-treesitter-playground/query.lua
+++ b/lua/nvim-treesitter-playground/query.lua
@@ -1,3 +1,4 @@
+local ts = require "nvim-treesitter.compat"
 local ts_query = require "nvim-treesitter.query"
 local parsers = require "nvim-treesitter.parsers"
 local locals = require "nvim-treesitter.locals"
@@ -8,7 +9,7 @@ function M.parse(bufnr, query, lang_tree)
   lang_tree = lang_tree or parsers.get_parser(bufnr)
 
   local success, parsed_query = pcall(function()
-    return vim.treesitter.parse_query(lang_tree:lang(), query)
+    return ts.parse_query(lang_tree:lang(), query)
   end)
 
   if not success then

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local ts = require "nvim-treesitter.compat"
 local queries = require "nvim-treesitter.query"
 local parsers = require "nvim-treesitter.parsers"
 local utils = require "nvim-treesitter.utils"
@@ -31,7 +32,7 @@ local function show_lints(buf, lints)
 end
 
 local function add_lint_for_node(node, buf, error_type, complete_message)
-  local node_text = vim.treesitter.query.get_node_text(node, buf):gsub("\n", " ")
+  local node_text = vim.treesitter.get_node_text(node, buf):gsub("\n", " ")
   local error_text = complete_message or error_type .. ": " .. node_text
   local error_range = { node:range() }
   table.insert(M.lints[buf], { type = error_type, range = error_range, message = error_text, node_text = node_text })
@@ -76,7 +77,7 @@ function M.lint(query_buf)
 
   local query_lang = M.guess_query_lang(query_buf)
 
-  local ok, parser_info = pcall(vim.treesitter.inspect_language, query_lang)
+  local ok, parser_info = pcall(vim.treesitter.language.inspect(), query_lang)
 
   if not ok then
     return
@@ -93,9 +94,9 @@ function M.lint(query_buf)
 
     local toplevel_node = utils.get_at_path(m, "toplevel-query.node")
     if toplevel_node and query_lang then
-      local query_text = vim.treesitter.query.get_node_text(toplevel_node, query_buf)
+      local query_text = vim.treesitter.get_node_text(toplevel_node, query_buf)
       local err
-      ok, err = pcall(vim.treesitter.parse_query, query_lang, query_text)
+      ok, err = pcall(ts.parse_query, query_lang, query_text)
       if not ok then
         add_lint_for_node(toplevel_node, query_buf, "Invalid Query", err)
       end
@@ -106,7 +107,7 @@ function M.lint(query_buf)
       local anonymous_node = utils.get_at_path(m, "anonymous_node.node")
       local node = named_node or anonymous_node
       if node then
-        local node_type = vim.treesitter.query.get_node_text(node, query_buf)
+        local node_type = vim.treesitter.get_node_text(node, query_buf)
 
         if anonymous_node then
           node_type = node_type:gsub('"(.*)".*$', "%1"):gsub("\\(.)", "%1")
@@ -127,7 +128,7 @@ function M.lint(query_buf)
       local field_node = utils.get_at_path(m, "field.node")
 
       if field_node then
-        local field_name = vim.treesitter.query.get_node_text(field_node, query_buf)
+        local field_name = vim.treesitter.get_node_text(field_node, query_buf)
         local found = vim.tbl_contains(parser_info.fields, field_name)
         if not found then
           add_lint_for_node(field_node, query_buf, "Invalid Field")

--- a/lua/nvim_treesitter_playground_query_omnifunc.lua
+++ b/lua/nvim_treesitter_playground_query_omnifunc.lua
@@ -13,7 +13,7 @@ function M.omnifunc(findstart, base)
   local buf = vim.api.nvim_get_current_buf()
   local query_lang = query_linter.guess_query_lang(buf)
 
-  local ok, parser_info = pcall(vim.treesitter.inspect_language, query_lang)
+  local ok, parser_info = pcall(vim.treesitter.language.inspect, query_lang)
 
   if ok then
     local items = {}


### PR DESCRIPTION
ref: neovim/neovim@cbbf8bd
