### PR TITLE
fix pcall of vim.treesitter.language.inspect

### DIFF
--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -77,7 +77,7 @@ function M.lint(query_buf)
 
   local query_lang = M.guess_query_lang(query_buf)
 
-  local ok, parser_info = pcall(vim.treesitter.language.inspect(), query_lang)
+  local ok, parser_info = pcall(vim.treesitter.language.inspect, query_lang)
 
   if not ok then
     return


### PR DESCRIPTION
This PR fixes an issue that was mentioned in the following comment.

https://github.com/nvim-treesitter/playground/issues/119#issuecomment-1501048844