### PR TITLE
fix: only have one source of `get_node_text` (nvim-treesitter.compat)

### DIFF
--- a/lua/nvim-treesitter-playground/internal.lua
+++ b/lua/nvim-treesitter-playground/internal.lua
@@ -9,6 +9,8 @@ local Promise = require "nvim-treesitter-playground.promise"
 local api = vim.api
 local luv = vim.loop
 
+local ts_compat = require "nvim-treesitter.compat"
+
 local M = {}
 
 local fs_mkdir = Promise.promisify(luv.fs_mkdir)
@@ -517,7 +519,7 @@ function M.update_query(bufnr, query_bufnr)
   for capture_match in ts_query.iter_group_results(query_bufnr, "captures") do
     table.insert(M._entries[bufnr].captures, capture_match.capture)
 
-    local capture = vim.treesitter.get_node_text(capture_match.capture.name.node, query_bufnr)
+    local capture = ts_compat.get_node_text(capture_match.capture.name.node, query_bufnr)
 
     if not capture_by_color[capture] then
       capture_by_color[capture] = "TSPlaygroundCapture" .. index
@@ -581,7 +583,7 @@ function M.on_query_cursor_move(bufnr)
     local _, _, capture_end = capture.def.node:end_()
     local _, _, start = node_at_point:start()
     local _, _, _end = node_at_point:end_()
-    local capture_name = vim.treesitter.get_node_text(capture.name.node, api.nvim_get_current_buf())
+    local capture_name = ts_compat.get_node_text(capture.name.node, api.nvim_get_current_buf())
 
     if start >= capture_start and _end <= capture_end and capture_name then
       M.highlight_matched_query_nodes_from_capture(bufnr, capture_name)

--- a/lua/nvim-treesitter-playground/query_linter.lua
+++ b/lua/nvim-treesitter-playground/query_linter.lua
@@ -4,6 +4,7 @@ local queries = require "nvim-treesitter.query"
 local parsers = require "nvim-treesitter.parsers"
 local utils = require "nvim-treesitter.utils"
 local configs = require "nvim-treesitter.configs"
+local ts_compat = require "nvim-treesitter.compat"
 
 local namespace = api.nvim_create_namespace "nvim-playground-lints"
 local MAGIC_NODE_NAMES = { "_", "ERROR" }
@@ -32,7 +33,7 @@ local function show_lints(buf, lints)
 end
 
 local function add_lint_for_node(node, buf, error_type, complete_message)
-  local node_text = vim.treesitter.get_node_text(node, buf):gsub("\n", " ")
+  local node_text = ts_compat.get_node_text(node, buf):gsub("\n", " ")
   local error_text = complete_message or error_type .. ": " .. node_text
   local error_range = { node:range() }
   table.insert(M.lints[buf], { type = error_type, range = error_range, message = error_text, node_text = node_text })
@@ -94,7 +95,7 @@ function M.lint(query_buf)
 
     local toplevel_node = utils.get_at_path(m, "toplevel-query.node")
     if toplevel_node and query_lang then
-      local query_text = vim.treesitter.get_node_text(toplevel_node, query_buf)
+      local query_text = ts_compat.get_node_text(toplevel_node, query_buf)
       local err
       ok, err = pcall(ts.parse_query, query_lang, query_text)
       if not ok then
@@ -107,7 +108,7 @@ function M.lint(query_buf)
       local anonymous_node = utils.get_at_path(m, "anonymous_node.node")
       local node = named_node or anonymous_node
       if node then
-        local node_type = vim.treesitter.get_node_text(node, query_buf)
+        local node_type = ts_compat.get_node_text(node, query_buf)
 
         if anonymous_node then
           node_type = node_type:gsub('"(.*)".*$', "%1"):gsub("\\(.)", "%1")
@@ -128,7 +129,7 @@ function M.lint(query_buf)
       local field_node = utils.get_at_path(m, "field.node")
 
       if field_node then
-        local field_name = vim.treesitter.get_node_text(field_node, query_buf)
+        local field_name = ts_compat.get_node_text(field_node, query_buf)
         local found = vim.tbl_contains(parser_info.fields, field_name)
         if not found then
           add_lint_for_node(field_node, query_buf, "Invalid Field")


### PR DESCRIPTION
PR #120 used nvim-treesitter.compat in some occasions but not all: https://github.com/nvim-treesitter/playground/pull/120/files

This made nvim-treesitter-playground incompatible with older Neovim versions https://github.com/nvim-treesitter/playground/pull/120#issuecomment-1509140602

Although, we generally only support latest Neovim stable this is a unnecessary inconsistency in the code base. Also when, ts_compat should be removed in future it should there will be only one source of `get_node_text` that can then be swapped consistently around the whole code base. nvim-treesitter-playground is especially useful for older Neovim versions that don't have the built-in playground yet.

@wookayin 